### PR TITLE
Fixing formating on parseheap command

### DIFF
--- a/angelheap/angelheap.py
+++ b/angelheap/angelheap.py
@@ -1149,7 +1149,7 @@ def parse_heap(arena=None):
     else :
         print("Can't find heap")
     chunkaddr = heapbase
-    print('\033[1;33m{:<20}{:<10}{:<10}{:<18}{:<18}{:<18}\033[0m'.format('addr', 'prev', 'size', 'status', 'fd', 'bk'))
+    print('\033[1;33m{:<20}{:<20}{:<21}{:<20}{:<18}{:<18}\033[0m'.format('addr', 'prev', 'size', 'status', 'fd', 'bk'))
     while chunkaddr != top["addr"] :
         try :
             cmd = "x/" + word + hex(chunkaddr)
@@ -1170,13 +1170,13 @@ def parse_heap(arena=None):
             if status :
                 if chunkaddr in fastchunk :
                     msg = "\033[1;34m Freed \033[0m"
-                    print('0x{:<18x}0x{:<8x}0x{:<8x}{:<16}{:>18}{:>18}'.format(chunkaddr, prev_size, size, msg, hex(fd), "None"))
+                    print('0x{:<18x}0x{:<18x}0x{:<18x}{:<16}{:>18}{:>18}'.format(chunkaddr, prev_size, size, msg, hex(fd), "None"))
                 else :
                     msg = "\033[31m Used \033[0m"
-                    print('0x{:<18x}0x{:<8x}0x{:<8x}{:<16}{:>18}{:>18}'.format(chunkaddr, prev_size, size, msg, "None", "None"))
+                    print('0x{:<18x}0x{:<18x}0x{:<18x}{:<16}{:>18}{:>18}'.format(chunkaddr, prev_size, size, msg, "None", "None"))
             else :
                 msg = "\033[1;34m Freed \033[0m"
-                print('0x{:<18x}0x{:<8x}0x{:<8x}{:<16}{:>18}{:>18}'.format(chunkaddr, prev_size, size, msg, hex(fd), hex(bk)))
+                print('0x{:<18x}0x{:<18x}0x{:<18x}{:<16}{:>18}{:>18}'.format(chunkaddr, prev_size, size, msg, hex(fd), hex(bk)))
             chunkaddr = chunkaddr + (size & 0xfffffffffffffff8)
 
             if chunkaddr > top["addr"] :


### PR DESCRIPTION
Currently the parseheap formatting is off with 64bit binaries, prev/size fields run into each other.
```
pwndbg> parseheap 
addr                prev      size      status            fd                bk                
0x562346c5a000      0x0       0x30       Used                None              None
0x562346c5a030      0x414141414141410x1010     Used                None              None
0x562346c5b040      0x0       0x210      Freed     0x7f270f8ccb78    0x7f270f8ccb78
0x562346c5b250      0x210     0x30       Used                None              None
0x562346c5b280      0x414141414141410x30       Freed                0x1              None
0x562346c5b2b0      0x31313131313131310x30       Used                None              None
0x562346c5b2e0      0x414141414141410x30       Used                None              None
0x562346c5b310      0xa000000000000000x30       Used                None              None
0x562346c5b340      0x414141414141410x30       Used                None              None
0x562346c5b370      0x414141414141410x30       Used                None              None
0x562346c5b3a0      0x414141414141410x30       Used                None              None
0x562346c5b3d0      0x34343434343434340x30       Used                None              None
0x562346c5b400      0x414141414141410x30       Used                None              None
0x562346c5b430      0x34343434343434340x30       Used                None              None
0x562346c5b460      0x414141414141410x30       Used                None              None
0x562346c5b490      0x34343434343434340x30       Used                None              None
0x562346c5b4c0      0x414141414141410x30       Used                None              None
0x562346c5b4f0      0x34343434343434340x30       Used                None              None
0x562346c5b520      0x414141414141410x30       Used                None              None
0x562346c5b550      0x34343434343434340x20       Used                None              None
```
I made changes so that formatting now looks like this:
```
pwndbg> parseheap 
addr                prev                size                 status              fd                bk                
0x559fb4b35000      0x0                 0x30                 Used                None              None
0x559fb4b35030      0x41414141414141    0x1010               Used                None              None
0x559fb4b36040      0x0                 0x210                Freed     0x7f0112f2bb78    0x7f0112f2bb78
0x559fb4b36250      0x210               0x30                 Used                None              None
0x559fb4b36280      0x41414141414141    0x30                 Freed                0x1              None
0x559fb4b362b0      0x3131313131313131  0x30                 Used                None              None
0x559fb4b362e0      0x41414141414141    0x30                 Used                None              None
0x559fb4b36310      0xa00000000000000   0x30                 Used                None              None
0x559fb4b36340      0x41414141414141    0x30                 Used                None              None
0x559fb4b36370      0x41414141414141    0x30                 Used                None              None
0x559fb4b363a0      0x41414141414141    0x30                 Used                None              None
0x559fb4b363d0      0x3434343434343434  0x30                 Used                None              None
0x559fb4b36400      0x41414141414141    0x30                 Used                None              None
0x559fb4b36430      0x3434343434343434  0x30                 Used                None              None
0x559fb4b36460      0x41414141414141    0x30                 Used                None              None
0x559fb4b36490      0x3434343434343434  0x30                 Used                None              None
0x559fb4b364c0      0x41414141414141    0x30                 Used                None              None
0x559fb4b364f0      0x3434343434343434  0x30                 Used                None              None
0x559fb4b36520      0x41414141414141    0x30                 Used                None              None
0x559fb4b36550      0x3434343434343434  0x20                 Used                None              None
```
