### PR TITLE
work with offsets for PIC binaries

### DIFF
--- a/pwngdb.py
+++ b/pwngdb.py
@@ -48,6 +48,8 @@ def normalize_argv(args, size=0):
 
 class PwnCmd(object):
     commands = []
+    prevbp = []
+    bpoff = []
     def __init__(self):
         # list all commands
         self.commands = [cmd for cmd in dir(self) if callable(getattr(self, cmd)) ]  
@@ -232,6 +234,62 @@ class PwnCmd(object):
                     addr = int(callbase.split(':')[0],16)
                     cmd = "b*" + hex(addr)
                     print(gdb.execute(cmd,to_string=True))
+
+    def boff(self,*arg):
+        """ Set the breakpoint at some offset from base address """
+        (sym,) = normalize_argv(arg,1)
+        codebaseaddr,codeend = codeaddr()
+        if sym not in self.bpoff:
+            self.bpoff.append(sym)
+        cmd = "b*" + hex(codebaseaddr + sym)
+        x = gdb.execute(cmd,to_string=True)
+        y = x.rstrip().split("\n")[-1].split()[1]
+        self.prevbp.append(y)
+        print(x.rstrip())
+
+    def tboff(self,*arg):
+        """ Set temporary breakpoint at some offset from base address """
+        (sym,) = normalize_argv(arg,1)
+        codebaseaddr,codeend = codeaddr()
+        cmd = "tb*" + hex(codebaseaddr + sym)
+        print(gdb.execute(cmd,to_string=True))
+
+    def atboff(self,*arg):
+        """ Attach and set breakpoints accordingly """
+        (sym,) = normalize_argv(arg,1)
+        cmd = "attach " + str(sym)
+        print(gdb.execute(cmd,to_string=True))
+        x = len(self.prevbp)
+        while x > 0:
+            i = self.prevbp.pop(0)
+            cmd = "del " + i
+            gdb.execute(cmd,to_string=True)
+            x -= 1
+        for i in self.bpoff:
+            self.boff(hex(i))
+
+    def doff(self,*arg):
+        """ Delete the breakpoint using breakpoint number at some offset from base address """
+        (sym,) = normalize_argv(arg,1)
+        if str(sym) not in self.prevbp:
+            return
+        codebaseaddr,codeend = codeaddr()
+        cmd = "i b " + str(sym)
+        x = gdb.execute(cmd,to_string=True)
+        y = int(x.rstrip().split("\n")[1].split()[4], 16) - codebaseaddr
+        cmd = "del " + str(sym)
+        print(gdb.execute(cmd,to_string=True).rstrip())
+        self.bpoff.remove(y)
+        self.prevbp.remove(str(sym))
+
+    def xo(self,*arg):
+        """ Examine at offset from base address """
+        (_,arg1,) = normalize_argv(arg,2)
+        cmd = "x" + arg[0] + " "
+        if arg1:
+            codebaseaddr,_ = codeaddr()
+            cmd += hex(codebaseaddr + arg1)
+        print(gdb.execute(cmd,to_string=True)[:-1])
 
 class PwngdbCmd(gdb.Command):
     """ Pwngdb command wrapper """


### PR DESCRIPTION
- boff <offset>: set breakpoint at given offset from code base address
- doff <breakpoint number>: delete breakpoint at given offset
- tboff <offset>: temporary breakpoint at given offset from code base address
- atboff <pid>: attach and reset breakpoints (set using boff) to respective new address
- xo <format address>: examine at offset

Mainly useful for debugging PIC binaries.