### PR TITLE
fixed `tls` command error

### DIFF
--- a/pwngdb.py
+++ b/pwngdb.py
@@ -442,7 +442,7 @@ def gettls():
             return "error"
         return tlsaddr
     elif arch == "x86-64" :
-        gdb.execute("call arch_prctl(0x1003,$rsp-8)")
+        gdb.execute("call (int)arch_prctl(0x1003,$rsp-8)",to_string=True)
         data = gdb.execute("x/xg $rsp-8",to_string=True)
         return int(data.split(":")[1].strip(),16)
     else:


### PR DESCRIPTION
When I use the `tls` command, it shows the following error:
```
Python Exception <class 'gdb.error'> 'arch_prctl' has unknown return type; cast the call to its declared return type: 
Python Exception <class 'gdb.error'> Error occurred in Python command: 'arch_prctl' has unknown return type; cast the call to its declared return type: 
Error occurred in Python command: Error occurred in Python command: 'arch_prctl' has unknown return type; cast the call to its declared return type
```
I add a return type to `arch_prctl`.