### PR TITLE
Make procmap work in angelheap while using mozilla rr

### DIFF
--- a/angelheap/angelheap.py
+++ b/angelheap/angelheap.py
@@ -7,6 +7,7 @@ import subprocess
 import re
 import copy
 import struct
+import os
 # main_arena
 main_arena = 0
 main_arena_off = 0 
@@ -324,6 +325,25 @@ def getarch():
     else :
         return "error"
 
+def infoprocmap():
+    """ Use gdb command 'info proc map' to get the memory mapping """
+    """ Notice: No permission info """
+    resp = gdb.execute("info proc map", to_string=True).split("\n")
+    resp = '\n'.join(resp[i] for i  in range(4, len(resp))).strip().split("\n")
+    infomap = ""
+    for l in resp:
+        line = ""
+        first = True
+        for sep in l.split(" "):
+            if len(sep) != 0:
+                if first: # start address
+                    line += sep + "-"
+                    first = False
+                else:
+                    line += sep + " "
+        line = line.strip() + "\n"
+        infomap += line
+    return infomap
 
 def procmap():
     data = gdb.execute('info proc exe',to_string = True)
@@ -331,10 +351,14 @@ def procmap():
     if pid :
         pid = pid.group()
         pid = pid.split()[1]
-        maps = open("/proc/" + pid + "/maps","r")
-        infomap = maps.read()
-        maps.close()
-        return infomap
+        fpath = "/proc/" + pid + "/maps"
+        if os.path.isfile(fpath): # if file exist, read memory mapping directly from file
+            maps = open(fpath)
+            infomap = maps.read()
+            maps.close()
+            return infomap
+        else: # if file doesn't exist, use 'info proc map' to get the memory mapping
+            return infoprocmap()
     else :
         return "error"
 


### PR DESCRIPTION
## Issue

While using [mozilla rr](https://github.com/mozilla/rr) and angelheap together, the plugin failed to examine the heap layout due to the following error:

```
.................................................
gdb.error: Error occurred in Python command: [Errno 2] No such file or directory: '/proc/9640/maps'
Error occurred in Python command: Error occurred in Python command: [Errno 2] No such file or directory: '/proc/9640/maps'
```

This is because rr only store the [recording pid](https://github.com/mozilla/rr/issues/1834). The replayed process had already gone, which is why Pwngdb failed to find the memory mapping of the process ( because the process no longer exist ).

## Patch 
We can still use the `info proc map` command to get the memory mapping.  
This PR patches the `procmap()` method in angelheap and uses `info proc map` to get the memory mappings once it found there's no `/proc/pid/maps` file.

## Result
Now it can use `heapinfo` and other heap-related command to examine the heap memory layout.  
(Notice: The malloc/free tracing in reverse order is not supported yet )

## Notice
Notice that **there is no memory permission's info ( aka `rwx` info ) in `info proc map`**, however since angelheap doesn't care about the info I don't think it's that much of a problem.  

Also I only apply the patch in angelheap, the one in `pwngdb.py` still remains the same. Feel free to apply the patch yourself if you want to.
