### PR TITLE
adjust result of function "fmtarg"

### DIFF
--- a/pwngdb.py
+++ b/pwngdb.py
@@ -605,11 +605,11 @@ def getfmtarg(addr):
     if capsize == 0 :
         getarch()
     if arch == "i386" :
-        start = get_reg("esp")
+        start = get_reg("esp") + 4
         idx = (addr- start)/4
         print("The index of format argument : %d" % idx)
     elif arch == "x86-64" :
-        start = get_reg("rsp")
+        start = get_reg("rsp") + 8
         idx = (addr - start)/8 + 6
         print("The index of format argument : %d" % idx)
     else :

--- a/pwngdb.py
+++ b/pwngdb.py
@@ -607,13 +607,12 @@ def getfmtarg(addr):
     if arch == "i386" :
         start = get_reg("esp") + 4
         idx = (addr- start)/4
-        print("The index of format argument : %d" % idx)
     elif arch == "x86-64" :
         start = get_reg("rsp") + 8
         idx = (addr - start)/8 + 6
-        print("The index of format argument : %d" % idx)
     else :
         print("Not support the arch")
+    print("The index of format argument : %d (\"\%%%d$p\")" % (idx,idx))
 
 pwncmd = PwnCmd()
 PwngdbCmd()


### PR DESCRIPTION
when you set breakpoint at "printf" and break, ESP actully point at the return address instead of first argument, so it's better that add the start address to make "fmtarg" more friendly to use