### PR TITLE
Fix: compatibility for new pwndbg #49

### DIFF
--- a/pwndbg/README.md
+++ b/pwndbg/README.md
@@ -1,5 +1,7 @@
 # Pwngdb ❤️ pwndbg
 
+Below instruction is tested based on Pwndbg: `2024.02.14 build: 90dc42e5`.
+
 ## How to install
 
 1. Put `pwngdb.py` and `angelheap.py` into `/path/to/pwndbg/pwndbg/`
@@ -22,8 +24,8 @@ cp angelheap.py $pwndbg/pwndbg/angelheap.py
 cp commands/pwngdb.py $pwndbg/pwndbg/commands/pwngdb.py
 cp commands/angelheap.py $pwndbg/pwndbg/commands/angelheap.py
 
-sed -i -e '/import pwndbg.commands.xor/a import pwndbg.commands.pwngdb' $pwndbg/pwndbg/__init__.py
-sed -i -e '/import pwndbg.commands.xor/a import pwndbg.commands.angelheap' $pwndbg/pwndbg/__init__.py
+sed -i -e '/config_mod.init_params()/a import pwndbg.commands.pwngdb' $pwndbg/pwndbg/__init__.py
+sed -i -e '/config_mod.init_params()/a import pwndbg.commands.angelheap' $pwndbg/pwndbg/__init__.py
 ```
 
 ## Note
@@ -33,6 +35,8 @@ To avoid the conflict with pwndbg, some commands will be different or be removed
 1. `got` will be renamed to `objdump_got`
 
 2. `canary` will be removed since pwndbg already has `canary` command
+
+3. `tls` will be renamed to `pwngdb_tls`
 
 ## TODO
 

--- a/pwndbg/angelheap.py
+++ b/pwndbg/angelheap.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Pwngdb by angenboy
+Pwngdb by angelboy
 
 https://github.com/scwuaptx/Pwngdb
 """
@@ -14,8 +14,8 @@ import copy
 import struct
 import os
 
-import pwndbg.arch
-import pwndbg.vmmap
+import pwndbg.gdblib.arch
+import pwndbg.gdblib.vmmap
 
 # main_arena
 main_arena = 0

--- a/pwndbg/angelheap.py
+++ b/pwndbg/angelheap.py
@@ -317,7 +317,7 @@ def getarch():
 
 def libcbase():
     for p in pwndbg.vmmap.get():
-        if re.search(".*libc-.*", p.objfile):
+        if re.search(r".*libc-.*", p.objfile):
             return p.start
     return 0
 

--- a/pwndbg/commands/angelheap.py
+++ b/pwndbg/commands/angelheap.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Pwngdb by angenboy
+Pwngdb by angelboy
 
 https://github.com/scwuaptx/Pwngdb
 """

--- a/pwndbg/commands/pwngdb.py
+++ b/pwndbg/commands/pwngdb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Pwngdb by angenboy
+Pwngdb by angelboy
 
 https://github.com/scwuaptx/Pwngdb
 """
@@ -16,12 +16,12 @@ import argparse
 import gdb
 
 import pwndbg.commands
-import pwndbg.arch
-import pwndbg.proc
+import pwndbg.gdblib.arch
+import pwndbg.gdblib.proc
 import pwndbg.search
-import pwndbg.regs
-import pwndbg.symbol
-import pwndbg.memory
+import pwndbg.gdblib.regs
+import pwndbg.gdblib.symbol
+import pwndbg.gdblib.memory
 import pwndbg.pwngdb as pwngdb
 
 
@@ -83,7 +83,7 @@ def codebase():
 
 @pwndbg.commands.ArgparsedCommand("Get tls base.")
 @pwndbg.commands.OnlyWhenRunning
-def tls():
+def pwngdb_tls():
     tlsaddr = pwngdb.gettls()
     if tlsaddr != -1:
         print("\033[34m" + "tls : " + "\033[37m" + hex(tlsaddr))

--- a/pwndbg/pwngdb.py
+++ b/pwndbg/pwngdb.py
@@ -48,7 +48,7 @@ def procmap():
 
 def libcbase():
     for p in pwndbg.vmmap.get():
-        if re.search(".*libc-.*", p.objfile):
+        if re.search(r".*libc-.*", p.objfile):
             libcaddr = p.start
             gdb.execute("set $libc={}".format(hex(libcaddr)))
             return libcaddr
@@ -57,7 +57,7 @@ def libcbase():
 
 def getheapbase():
     for p in pwndbg.vmmap.get():
-        if re.search(".*heap\]", p.objfile):
+        if re.search(r".*heap\]", p.objfile):
             heapbase = p.start
             gdb.execute("set $heap={}".format(hex(heapbase)))
             return heapbase
@@ -66,7 +66,7 @@ def getheapbase():
 
 def ldbase():
     for p in pwndbg.vmmap.get():
-        if re.search(".*ld.*\.so", p.objfile):
+        if re.search(r".*ld.*\.so", p.objfile):
             ldbase = p.start
             gdb.execute("set $ld={}".format(hex(ldbase)))
             return ldbase

--- a/pwndbg/pwngdb.py
+++ b/pwndbg/pwngdb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Pwngdb by angenboy
+Pwngdb by angelboy
 
 https://github.com/scwuaptx/Pwngdb
 """
@@ -16,12 +16,12 @@ import subprocess
 
 import gdb
 
-import pwndbg.arch
-import pwndbg.proc
+import pwndbg.gdblib.arch
+import pwndbg.gdblib.proc
 import pwndbg.search
-import pwndbg.symbol
-import pwndbg.memory
-import pwndbg.vmmap
+import pwndbg.gdblib.symbol
+import pwndbg.gdblib.memory
+import pwndbg.gdblib.vmmap
 
 magic_variable = ["__malloc_hook", "__free_hook", "__realloc_hook", "stdin", "stdout", "_IO_list_all",
                   "__after_morecore_hook"]


### PR DESCRIPTION
**Please Notice**:
[pwndbg](https://github.com/pwndbg/pwndbg) changes its api and codebase structure pretty often. So pwndbg version here I use is `2024.02.14 build: 90dc42e5` Notice that the code structure the version of `pwndbg`'s  I try to fixed is different from now (July 2024). You can clone the [pwndbg](https://github.com/pwndbg/pwndbg) repository and checkout to that commit hash.

In newer pwndbg there is no `pwndbg.commands.xor` in `pwndbg/init.py`, which resulting in failed installation. So I fixed it by adding after `config_mod.init_params()`, which is the last line of `init.py`. ( #49 )

And some of the api in [pwndbg](https://github.com/pwndbg/pwndbg) has changed, like `pwndbg.arch` is now `pwndbg.gdblib.arch` so I update them. I also fixed some syntax warnings and typo.

Finally now pwndbg has `tls` command implementation so I rename `tls` command here to `pwngdb_tls`. 