### PR TITLE
insert gdblib in the middle of symbol package

### DIFF
--- a/pwndbg/commands/pwngdb.py
+++ b/pwndbg/commands/pwngdb.py
@@ -178,7 +178,7 @@ def magic():
         print("\033[34m" + f  + ":" + "\033[33m" +hex(pwngdb.getoff(f))) 
     print("\033[00m========== variables ==========")
     for v in pwngdb.magic_variable:
-        addr = pwndbg.symbol.address(v)
+        addr = pwndbg.gdblib.symbol.address(v)
         if addr is None:
             print("\033[34m" + v + ":" + "\033[33m" + "not found")
         offset = addr - pwngdb.libcbase()


### PR DESCRIPTION
**Contribution Info**
I Fix crash when using ```magic``` command in Pwngdb. 

**Reason**
Reason that i've missed the change package to insert the gdblib in commands/pwngdb. So i insert the package which pwndbg.symbol.address() to pwndbg.gdblib.symbol.address().

**Test result** 
It works properly in pwndbg ```90dc42e5``` commit version. 