### PR TITLE
Update pwngdb.py

### DIFF
--- a/pwngdb.py
+++ b/pwngdb.py
@@ -403,7 +403,8 @@ def getprocname(relative=False):
 
 def libcbase():
     infomap = procmap()
-    data = re.search(r".*libc.*\.so",infomap)
+    #data = re.search(r".*libc.*\.so",infomap)
+    data = re.search(r".*libc(-\d+\.\d+)?\.so(\.\d+)*$", infomap, re.MULTILINE)
     if data :
         libcaddr = data.group().split("-")[0]
         gdb.execute("set $libc=%s" % hex(int(libcaddr,16)))


### PR DESCRIPTION
fix libc may show libcrypto base addr
I used `libc` command to show libc base addr, but it showed libcrypto base addr
```sh
0x7f243e143000     0x7f243e1f5000 r--p    b2000      0 /usr/lib/x86_64-linux-gnu/libcrypto.so.3
```
So I read the related source code and find this rule has little problem
```python
 data = re.search(r".*libc.*\.so",infomap)
```
It doesn't filter libc*** file. So if this file is above the libc file, Pwngdb will give the wrong file base addr to us.
I just change this match rule as below
```python
data = re.search(r".*libc(-\d+\.\d+)?\.so(\.\d+)*$", infomap, re.MULTILINE)
```
It solves the problem I mentioned. And it works on libc name `libc.so.6` and `libc-2.35.so`.
Thank scwuaptx creating so interesting tool to help me studying PWN, I wanna make a contribution to it